### PR TITLE
2回リクエストしてランダマイズする機能追加

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,38 +2,54 @@ const http = require('http');
 
 const getData = (url) => {
     const localURL = new URL('http://yumuta.github.io/vocaminer/'+url);
-    const requestURL = new URL('http://api.search.nicovideo.jp/api/v2/video/contents/search?q=ミクオリジナル曲&targets=tagsExact&fields=contentId,title&filters[viewCounter][gte]=100&filters[viewCounter][lte]=1000&_sort=-lastCommentTime&_offset=0&_limit=100&_context=apiguide');
-    requestURL.searchParams.set('q', localURL.searchParams.get('q'));
-    requestURL.searchParams.set('filters[viewCounter][gte]', localURL.searchParams.get('viewgte'));
-    requestURL.searchParams.set('filters[viewCounter][lte]', localURL.searchParams.get('viewlte'));
+    const requestURL = new URL('http://api.search.nicovideo.jp/api/v2/video/contents/search');
+    requestURL.searchParams.set('q', localURL.searchParams.get('q') || 'ミクオリジナル曲');
+    requestURL.searchParams.set('targets', 'tagsExact');
+    requestURL.searchParams.set('filters[viewCounter][gte]', localURL.searchParams.get('viewgte') || 100);
+    requestURL.searchParams.set('filters[viewCounter][lte]', localURL.searchParams.get('viewlte') || 1000);
+    requestURL.searchParams.set('_limit', 1);
+    // TODO: ソート方法をランダマイズ
+    requestURL.searchParams.set('_sort', '-lastCommentTime');
+    // TODO: contextはvocaminerでよさそう
+    requestURL.searchParams.set('_context', 'apiguide');
     return new Promise((resolve, reject)=>{
-        http.get(requestURL.href, (res1)=>{
-            let chunk = "";
-            res1.on('data',(receivedData) => {
-                chunk+=receivedData
-            }).on('end', ()=>{
-                let json = null;
-                try{
-                    json = JSON.parse(chunk);
-                } catch(e) {
-                    reject('JSON parse error');
-                    return;
-                }
-                if(json.meta.status !== 200) {
-                    reject('response is not 200');
-                    return;
-                }
-                const movieNum = json.data.length;
-                if(movieNum === 0) reject('noResult');
-                let pickedUpMovie = json.data[Math.floor(Math.random()*movieNum)];
-                resolve(pickedUpMovie);
-            });
-        }).on('error',(e)=>{
+        http.get(requestURL.href, res => {
+            const count = res.headers['x-total-count'];
+            requestURL.searchParams.set('fields', 'contentId,title');
+            requestURL.searchParams.set('_offset', getOffset(count));
+            http.get(requestURL.href, (res1) => {
+                let chunk = "";
+                res1.on('data', (receivedData) => {
+                    chunk += receivedData
+                }).on('end', () => {
+                    let json = null;
+                    try {
+                        json = JSON.parse(chunk);
+                    } catch (e) {
+                        reject('JSON parse error');
+                        return;
+                    }
+                    if (json.meta.status !== 200) {
+                        reject('response is not 200');
+                        return;
+                    }
+                    const movieNum = json.data.length;
+                    if (movieNum === 0) reject('noResult');
+                    resolve(json.data[0]);
+                });
+            }).on('error', (e) => {
+                reject(e);
+            }).end();
+        }).on('error', (e) => {
             reject(e);
         }).end();
     });
 };
 
+const getOffset = (count) => {
+    maxOffset = Math.min(1600, count);
+    return Math.floor(Math.random() * maxOffset);
+};
 
 const server = http.createServer((req, res) => {
     if(req.method !== 'GET') return;


### PR DESCRIPTION
サーバ側で2回リクエスト投げる機能を追加しました。
- 1回目：Headerから総数だけ取得
- 2回目：総数からoffsetをランダムに計算し、そのoffsetを指定&limit=1で取得して返す

思ったこと
- コールバック増えて微妙になったのでサーバ側でfetch使うモジュール等入れてもいいかも（[node-fetch](https://www.npmjs.com/package/node-fetch)とか）
- サーバ側にExpress等の簡単なフレームワーク入れてもいいかも（処理が増えてくると分かりづらくなってきそう）